### PR TITLE
fix compatibility issue with new doors api

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -116,7 +116,7 @@ minetest.register_abm({
       chance = 1,
       catch_up = false,
       action = function(pos, node)
-	 minetest.after(1, b1rc, pos, node, "")
+	 minetest.after(1, b1rc, pos, node, nil)
       end
 })
 


### PR DESCRIPTION
With new doors API clicker object is check for wield item (key functionality). Empty string transforms into 'true' and doors mod proceed it as a player and fail. Better use nill in this case.

https://github.com/minetest/minetest_game/blob/master/mods/doors/init.lua#L142